### PR TITLE
Directory write permission checking.

### DIFF
--- a/src/NAppUpdate.Updater/AppStart.cs
+++ b/src/NAppUpdate.Updater/AppStart.cs
@@ -32,7 +32,7 @@ namespace NAppUpdate.Updater
 
         private static void Main()
         {
-            //Debugger.Launch();
+            Debugger.Launch();
             try
             {
                 // Get the update process name, to be used to create a named pipe and to wait on the application
@@ -117,6 +117,10 @@ namespace NAppUpdate.Updater
                 {
                     if (Directory.Exists(backupFolder))
                         Directory.Delete(backupFolder, true);
+                }
+                else
+                {
+                    MessageBox.Show("Update Failed.");
                 }
 
                 // Start the application only if requested to do so


### PR DESCRIPTION
Some directory write permission checking, both in Updater.exe and in line 222 onwards on UpdateMagnager.cs. I also put a bit in Updater.exe so it alerts if the update failed. Might be worth passing this back to the orignial app so it can display in its own way, as Jamie suggested.
