### PR TITLE
Minor commit before 0.1 tag?

### DIFF
--- a/src/NAppUpdate.Tests/UtilTests/PermissionsCheckTest.cs
+++ b/src/NAppUpdate.Tests/UtilTests/PermissionsCheckTest.cs
@@ -1,0 +1,94 @@
+﻿using NAppUpdate.Framework.Utils;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace NAppUpdate.Tests
+{
+
+
+    /// <summary>
+    ///This is a test class for PermissionsCheckTest and is intended
+    ///to contain all PermissionsCheckTest Unit Tests
+    ///</summary>
+    [TestClass()]
+    public class PermissionsCheckTest
+    {
+
+
+        private TestContext testContextInstance;
+
+        /// <summary>
+        ///Gets or sets the test context which provides
+        ///information about and functionality for the current test run.
+        ///</summary>
+        public TestContext TestContext
+        {
+            get
+            {
+                return testContextInstance;
+            }
+            set
+            {
+                testContextInstance = value;
+            }
+        }
+
+        #region Additional test attributes
+        // 
+        //You can use the following additional attributes as you write your tests:
+        //
+        //Use ClassInitialize to run code before running the first test in the class
+        //[ClassInitialize()]
+        //public static void MyClassInitialize(TestContext testContext)
+        //{
+        //}
+        //
+        //Use ClassCleanup to run code after all tests in a class have run
+        //[ClassCleanup()]
+        //public static void MyClassCleanup()
+        //{
+        //}
+        //
+        //Use TestInitialize to run code before running each test
+        //[TestInitialize()]
+        //public void MyTestInitialize()
+        //{
+        //}
+        //
+        //Use TestCleanup to run code after each test has run
+        //[TestCleanup()]
+        //public void MyTestCleanup()
+        //{
+        //}
+        //
+        #endregion
+
+
+        /// <summary>
+        /// Test whether HaveWritePermissionsForFolder correctly returns on folder for which write permissions are permitted
+        ///</summary>
+        [TestMethod()]
+        public void HaveWritePermissionsForFolderTest()
+        {
+            string path = Path.GetTempPath(); //Guaranteed writable (I believe)
+            bool expected = true; // TODO: Initialize to an appropriate value
+            bool actual;
+            actual = PermissionsCheck.HaveWritePermissionsForFolder(path);
+            Assert.AreEqual(expected, actual);
+        }
+
+        /// <summary>
+        /// Test whether HaveWritePermissionsForFolder correctly returns on folder for which write permissions are not granted
+        /// </summary>
+        [TestMethod()]
+        public void HaveWritePermissionsForFolderDeniedTest()
+        {
+            string path = Environment.GetFolderPath(Environment.SpecialFolder.SystemX86);
+            bool expected = false; // TODO: Initialize to an appropriate value
+            bool actual;
+            actual = PermissionsCheck.HaveWritePermissionsForFolder(path);
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/src/NAppUpdate.Updater/AppStart.cs
+++ b/src/NAppUpdate.Updater/AppStart.cs
@@ -32,7 +32,9 @@ namespace NAppUpdate.Updater
 
         private static void Main()
         {
-            //Debugger.Launch();
+#if DEBUG
+            Debugger.Launch();
+#endif
             try
             {
                 // Get the update process name, to be used to create a named pipe and to wait on the application


### PR DESCRIPTION
hi - just had a couple of minor things to add before you tagged 0.1.

First is a simple test for PermissionsCheck util method. I need to test this test on other OS's - it's entirely possible it'll fail on non-Vista/7 OS, because the regular user might have write access to c:\windows\system32. A better test would be for the test to create a directory. Set a different user deny write, impersonate that user, test for writes and then return. At least this is a start... :)

The only other change was a suggestion around Debug.Launch() in update.exe - I've added a compiler conditional so that it only fires if it's a Debug build. You might find this useful, feel free to discard.

Andrew
