### PR TITLE
Small fix to WPF example

### DIFF
--- a/Samples/WPFSampleApp/MainWindow.xaml.cs
+++ b/Samples/WPFSampleApp/MainWindow.xaml.cs
@@ -1,9 +1,8 @@
 ﻿using System;
+using System.IO;
 using System.Reflection;
 using System.Windows;
 using NAppUpdate.Framework;
-using Path=System.IO.Path;
-using System.IO;
 
 namespace NAppUpdate.SampleApp
 {
@@ -31,8 +30,15 @@ namespace NAppUpdate.SampleApp
             updManager.CheckForUpdateAsync(new NAppUpdate.Framework.Sources.MemorySource(File.ReadAllText("sampleappupdatefeed.xml"))
                 , updatesCount =>
                 {
+                    Action showUpdateAction = () => new UpdateWindow(UpdateManager.Instance).Show();
+
                     if (updatesCount > 0)
-                        new UpdateWindow(updManager).Show();
+                    {
+                        if (Dispatcher.CheckAccess())
+                            showUpdateAction();
+                        else
+                            Dispatcher.Invoke(showUpdateAction);
+                    }
                 });
         }
     }


### PR DESCRIPTION
Fixed the issue where the Update window wasn't loading because the callback is executed on a worker thread.
