### PR TITLE
create subdirectories if necessary when backing up files

### DIFF
--- a/src/NAppUpdate.Framework/Tasks/FileUpdateTask.cs
+++ b/src/NAppUpdate.Framework/Tasks/FileUpdateTask.cs
@@ -87,7 +87,11 @@ namespace NAppUpdate.Framework.Tasks
 
             // Create a backup copy if target exists
             if (File.Exists(destinationFile))
+            {
+                if (!Directory.Exists(Path.GetDirectoryName(Path.Combine(UpdateManager.Instance.BackupFolder, LocalPath))))
+                    Utils.FileSystem.CreateDirectoryStructure(Path.GetDirectoryName(Path.Combine(UpdateManager.Instance.BackupFolder, LocalPath)), false);
                 File.Copy(destinationFile, Path.Combine(UpdateManager.Instance.BackupFolder, LocalPath));
+            }
 
             // Only enable execution if the apply attribute was set to hot-swap
             if (CanHotSwap)


### PR DESCRIPTION
UpdateFeed example:

``` xml
<Feed>
  <Tasks>
    <FileUpdateTask hotswap="false" updateTo="subdirectory\remotefile.dll" localPath="subdirectory\localfile.dll">
      <Description />
    </FileUpdateTask>
  </Tasks>
</Feed>
```

FileUpdateTask.Execute tries to do a backup if the destination file already exists, but does not create subdirectories to the backup folder if needed; therefore, a DirectoryNotFoundException is thrown:

System.IO.DirectoryNotFoundException: Could not find a part of the path 'C:\work\myproject\Backup\subdirectory\localfile.dll'.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.File.InternalCopy(String sourceFileName, String destFileName, Boolean overwrite)
   at System.IO.File.Copy(String sourceFileName, String destFileName)
   at NAppUpdate.Framework.Tasks.FileUpdateTask.Execute()
   at NAppUpdate.Framework.UpdateManager.ApplyUpdates(Boolean relaunchApplication)
   at aviita.CAF.client.util.AppUpdater.CheckForUpdates(AppUpdaterMode updaterMode)

suggested change creates subdirectories in the backup folder if necessary.
