### PR TITLE
Remove IPC from updater app relaunch

### DIFF
--- a/src/NAppUpdate.Framework/UpdateManager.cs
+++ b/src/NAppUpdate.Framework/UpdateManager.cs
@@ -450,6 +450,7 @@ namespace NAppUpdate.Framework
 						          		WorkingDirectory = Environment.CurrentDirectory,
 						          		RelaunchApplication = relaunchApplication,
 						          		LogItems = Logger.LogItems,
+                                        ProcessId = Process.GetCurrentProcess().Id
 						          	};
 
 						NauIpc.ExtractUpdaterFromResource(Config.TempFolder, Instance.Config.UpdateExecutableName);

--- a/src/NAppUpdate.Framework/Utils/NauIpc.cs
+++ b/src/NAppUpdate.Framework/Utils/NauIpc.cs
@@ -26,6 +26,7 @@ namespace NAppUpdate.Framework.Utils
 			public string AppPath { get; set; }
 			public string WorkingDirectory { get; set; }
 			public bool RelaunchApplication { get; set; }
+            public int ProcessId { get; set; }
 		}
 
 		[DllImport("kernel32.dll", SetLastError = true)]

--- a/src/NAppUpdate.Updater/AppStart.cs
+++ b/src/NAppUpdate.Updater/AppStart.cs
@@ -179,9 +179,11 @@ namespace NAppUpdate.Updater
 					           		FileName = appPath,
 					           	};
 					
-					var p = NauIpc.LaunchProcessAndSendDto(dto, info, syncProcessName);
-					if (p == null)
-						throw new UpdateProcessFailedException("Unable to relaunch application");
+                    try {
+                        Process.Start(info);
+                    } catch(Exception) {
+                        throw new UpdateProcessFailedException("Unable to relaunch application");
+                    }
 				}
 
 				Log("All done");

--- a/src/NAppUpdate.Updater/AppStart.cs
+++ b/src/NAppUpdate.Updater/AppStart.cs
@@ -94,6 +94,8 @@ namespace NAppUpdate.Updater
 					}
 				}
 
+                WaitForProcessTerminate(dto);
+
 				bool updateSuccessful = true;
 
 				if (dto == null || dto.Configs == null)
@@ -220,7 +222,26 @@ namespace NAppUpdate.Updater
 			}
 		}
 
-		private static void SelfCleanUp(string tempFolder)
+	    private static void WaitForProcessTerminate(NauIpc.NauDto dto) {
+	        try {
+	            if (dto != null) {
+	                int i = 0;
+	                do {
+	                    Process.GetProcessById(dto.ProcessId);
+	                    Log("Process {0} still running...", dto.ProcessId);
+	                    i++;
+	                    Thread.Sleep(500);
+	                } while (i <= 3);
+	                Log("Killing process {0}...", dto.ProcessId);
+	                Process.GetProcessById(dto.ProcessId).Kill();
+	            }
+	        }
+	        catch (Exception) {
+	            // parent process has exited
+	        }
+	    }
+
+	    private static void SelfCleanUp(string tempFolder)
 		{
 			// Delete the updater EXE and the temp folder
 			Log("Removing updater and temp folder... {0}", tempFolder);


### PR DESCRIPTION
Commit removes the IPC call and replaces it with a simple process start.

First, the updater doesn't have to push information to the app process (as far as I can see).
Second, this causes major trouble on applying multiple updates with "update chains" (multiple updates without closing the application between the updates). This comes because the first update process (foo.exe) blocks the named pipe what makes it impossible for the second update to start the cold update process.