### PR TITLE
Improved the process launch error handling

### DIFF
--- a/src/NAppUpdate.Framework/UpdateManager.cs
+++ b/src/NAppUpdate.Framework/UpdateManager.cs
@@ -483,8 +483,15 @@ namespace NAppUpdate.Framework
 
 						bool createdNew;
 						_shutdownMutex = new Mutex(true, Config.UpdateProcessName + "Mutex", out createdNew);
-						if (NauIpc.LaunchProcessAndSendDto(dto, info, Config.UpdateProcessName) == null)
-							throw new UpdateProcessFailedException("Could not launch cold update process");
+
+						try
+						{
+							NauIpc.LaunchProcessAndSendDto(dto, info, Config.UpdateProcessName);
+						}
+						catch (Exception ex)
+						{
+							throw new UpdateProcessFailedException("Could not launch cold update process", ex);
+						}
 
 						Environment.Exit(0);
 					}

--- a/src/NAppUpdate.Framework/Utils/NauIpc.cs
+++ b/src/NAppUpdate.Framework/Utils/NauIpc.cs
@@ -101,24 +101,24 @@ namespace NAppUpdate.Framework.Utils
 				   IntPtr.Zero))
 			{
 				//failed to create named pipe
-				if (state.clientPipeHandle.IsInvalid) return null;
-
-				try
+				if (state.clientPipeHandle.IsInvalid)
 				{
-					p = Process.Start(processStartInfo);
+					throw new Exception("Launch process client: Failed to create named pipe, handle is invalid.");
 				}
-				catch (Win32Exception)
-				{
-					// Person denied UAC escallation
-					return null;
-				}
-
+				
+				// This will throw Win32Exception if the user denies UAC
+				p = Process.Start(processStartInfo);
+				
 				ThreadPool.QueueUserWorkItem(ConnectPipe, state);
 				//A rather arbitary five seconds, perhaps better to be user configurable at some point?
 				state.eventWaitHandle.WaitOne(10000);
 
 				//failed to connect client pipe
-				if (state.result == 0) return null;
+				if (state.result == 0)
+				{
+					throw new Exception("Launch process client: Failed to connect to named pipe");
+				}
+
 				//client connection successfull
 				using (var fStream = new FileStream(state.clientPipeHandle, FileAccess.Write, (int)BUFFER_SIZE, true))
 				{

--- a/src/NAppUpdate.Updater/AppStart.cs
+++ b/src/NAppUpdate.Updater/AppStart.cs
@@ -175,8 +175,14 @@ namespace NAppUpdate.Updater
 						};
 					}
 
-					var p = NauIpc.LaunchProcessAndSendDto(dto, info, syncProcessName);
-					if (p == null) throw new UpdateProcessFailedException("Unable to relaunch application and/or send DTO");
+					try
+					{
+						NauIpc.LaunchProcessAndSendDto(dto, info, syncProcessName);
+					}
+					catch (Exception ex)
+					{
+						throw new UpdateProcessFailedException("Unable to relaunch application and/or send DTO", ex);
+					}
 				}
 
 				Log("All done");


### PR DESCRIPTION
I improved the error handling if something fails when launching a process.

The old implementation returned null if something went wrong and then threw an `UpdateProcessFailedException`, this implementation throws an exception which is being caught and set as inner exception on the `UpdateProcessFailedException` to preserve the information on exactly what went wrong.

This change is not breaking since it just adds more information to the `UpdateProcessFailedException`.

The reason for the change is to enable us to debug #54 