### PR TITLE
± small fix for hash condition check => changed to case insensitive.

### DIFF
--- a/src/NAppUpdate.Framework/Conditions/FileChecksumCondition.cs
+++ b/src/NAppUpdate.Framework/Conditions/FileChecksumCondition.cs
@@ -34,7 +34,7 @@ namespace NAppUpdate.Framework.Conditions
             if ("sha256".Equals(ChecksumType, StringComparison.InvariantCultureIgnoreCase))
             {
                 var sha256 = Utils.FileChecksum.GetSHA256Checksum(localPath);
-                if (!string.IsNullOrEmpty(sha256) && sha256.Equals(Checksum))
+                if (!string.IsNullOrEmpty(sha256) && sha256.Equals(Checksum, StringComparison.InvariantCultureIgnoreCase))
                     return true;
             }
 


### PR DESCRIPTION
when hash check is case sensitive, it cause the framework to keep updating the affected file when feed file FileChecksumCondition's hash value contains lower case chars.
Making string comparison to ignore case solves the issue.