### PR TITLE
#72 Cleaned up inconsistent method signatures

### DIFF
--- a/Samples/WinFormsSampleApp/frmMain.cs
+++ b/Samples/WinFormsSampleApp/frmMain.cs
@@ -81,6 +81,7 @@ namespace WinFormsSampleApp
 		{
 			// Get a local pointer to the UpdateManager instance
 			UpdateManager updManager = UpdateManager.Instance;
+			updManager.UpdateSource = source;
 
 			// Only check for updates if we haven't done so already
 			if (updManager.State != UpdateManager.UpdateProcessState.NotChecked)
@@ -94,7 +95,7 @@ namespace WinFormsSampleApp
 				// Check for updates - returns true if relevant updates are found (after processing all the tasks and
 				// conditions)
 				// Throws exceptions in case of bad arguments or unexpected results
-				updManager.CheckForUpdates(source);
+				updManager.CheckForUpdates();
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
As mentioned in #72 the PrepareUpdates() will throw an error if you call CheckForUpdates(IUpdateSource source) without also setting the UpdateManager property.

This is quite inconsistent and I felt that the best approach to making the behavior consistent is to remove the CheckForUpdates(IUpdateSource source) signature and instead always use the UpdateManager property.

This is a breaking change, but I do not think the breaking part is that critical since the updates probably will throw exceptions for the people that use CheckForUpdates(IUpdateSource source) instead of CheckForUpdates().

Also made some minor cleanups in the CheckForUpdates() error handling.
