### PR TITLE
Feedbuilder config fixes

### DIFF
--- a/FeedBuilder/FeedBuilder.csproj
+++ b/FeedBuilder/FeedBuilder.csproj
@@ -55,7 +55,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>
-    <OutputPath>..\bin\Debug\</OutputPath>
+    <OutputPath>bin\Debug\</OutputPath>
     <DocumentationFile>FeedBuilder.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
     <DebugType>full</DebugType>

--- a/FeedBuilder/FeedBuilderSettingsProvider.cs
+++ b/FeedBuilder/FeedBuilderSettingsProvider.cs
@@ -36,8 +36,8 @@ namespace FeedBuilder
 			{
 				string dest = Path.Combine(GetAppSettingsPath(), GetAppSettingsFilename());
 				if (filename == dest) return;
-				File.Copy(filename, dest, true);
 				Settings.Default.Reset();
+				File.Copy(filename, dest, true);
 			}
 			catch (Exception ex)
 			{
@@ -293,6 +293,8 @@ namespace FeedBuilder
 
 		public void Reset(SettingsContext context)
 		{
+			string settingsFilePath = Path.Combine(GetAppSettingsPath(), GetAppSettingsFilename());
+			File.Delete(settingsFilePath);
 			m_SettingsXML = null;
 		}
 

--- a/FeedBuilder/FeedBuilderSettingsProvider.cs
+++ b/FeedBuilder/FeedBuilderSettingsProvider.cs
@@ -10,7 +10,7 @@ using System.Xml.Serialization;
 
 namespace FeedBuilder
 {
-	public class FeedBuilderSettingsProvider : SettingsProvider
+	public class FeedBuilderSettingsProvider : SettingsProvider, IApplicationSettingsProvider
 	{
 		//XML Root Node
 		private const string SETTINGSROOT = "Settings";
@@ -37,7 +37,7 @@ namespace FeedBuilder
 				string dest = Path.Combine(GetAppSettingsPath(), GetAppSettingsFilename());
 				if (filename == dest) return;
 				File.Copy(filename, dest, true);
-				Settings.Default.Reload();
+				Settings.Default.Reset();
 			}
 			catch (Exception ex)
 			{
@@ -275,5 +275,17 @@ namespace FeedBuilder
 			}
 			return false;
 		}
+
+		public void Reset(SettingsContext context)
+		{
+			m_SettingsXML = null;
+		}
+
+		public SettingsPropertyValue GetPreviousVersion(SettingsContext context, SettingsProperty property)
+		{
+			return null;
+		}
+
+		public void Upgrade(SettingsContext context, SettingsPropertyCollection properties)	{ }
 	}
 }

--- a/FeedBuilder/FeedBuilderSettingsProvider.cs
+++ b/FeedBuilder/FeedBuilderSettingsProvider.cs
@@ -131,6 +131,21 @@ namespace FeedBuilder
 					try
 					{
 						m_SettingsXML.Load(Path.Combine(GetAppSettingsPath(), GetAppSettingsFilename()));
+						XmlNode node = m_SettingsXML.SelectSingleNode(string.Format("{0}/*", SETTINGSROOT));
+
+						// Adopt configuration if it is from another machine.
+						if (node != null && node.Name != Environment.MachineName)
+						{
+							XmlNode machineNode = m_SettingsXML.CreateElement(Environment.MachineName);
+
+							while (node.ChildNodes.Count > 0)
+							{
+								machineNode.AppendChild(node.FirstChild);
+							}
+
+							node.ParentNode.AppendChild(machineNode);
+							node.ParentNode.RemoveChild(node);
+						}
 					}
 					catch (Exception)
 					{

--- a/FeedBuilder/FeedBuilderSettingsProvider.cs
+++ b/FeedBuilder/FeedBuilderSettingsProvider.cs
@@ -262,7 +262,7 @@ namespace FeedBuilder
 				xmlWriter.Close();
 				node.InnerXml = builder.ToString();
 			}
-			else node.InnerText = propVal.SerializedValue.ToString();
+			else node.InnerText = propVal.SerializedValue != null ? propVal.SerializedValue.ToString() : string.Empty;
 		}
 
 		private bool IsRoaming(SettingsProperty prop)

--- a/FeedBuilder/frmMain.cs
+++ b/FeedBuilder/frmMain.cs
@@ -436,7 +436,7 @@ namespace FeedBuilder
 			}
 
 			string dir = GetFullDirectoryPath(path);
-			if (dir == null) return;
+
 			CreateDirectoryPath(dir);
 			Process process = new Process
 			{

--- a/FeedBuilder/frmMain.cs
+++ b/FeedBuilder/frmMain.cs
@@ -110,7 +110,6 @@ namespace FeedBuilder
 
 		private void SaveFormSettings()
 		{
-
 			if (!string.IsNullOrEmpty(txtOutputFolder.Text.Trim()) && Directory.Exists(txtOutputFolder.Text.Trim())) Settings.Default.OutputFolder = txtOutputFolder.Text.Trim();
 			// ReSharper disable AssignNullToNotNullAttribute
 			if (!string.IsNullOrEmpty(txtFeedXML.Text.Trim()) && Directory.Exists(Path.GetDirectoryName(txtFeedXML.Text.Trim()))) Settings.Default.FeedXML = txtFeedXML.Text.Trim();
@@ -140,6 +139,7 @@ namespace FeedBuilder
 		private void frmMain_FormClosing(object sender, FormClosingEventArgs e)
 		{
 			SaveFormSettings();
+			Settings.Default.Save();
 		}
 
 		#endregion

--- a/FeedBuilder/frmMain.cs
+++ b/FeedBuilder/frmMain.cs
@@ -59,14 +59,16 @@ namespace FeedBuilder
 				{
 					FeedBuilderSettingsProvider p = new FeedBuilderSettingsProvider();
 					p.LoadFrom(FileName);
+					InitializeFormSettings();
 				}
 				else
 				{
 					_argParser.ShowGui = true;
 					_argParser.Build = false;
-					FileName = _argParser.FileName;
-					UpdateTitle();
 				}
+
+				FileName = _argParser.FileName;
+				UpdateTitle();
 			}
 			if (_argParser.ShowGui) Show();
 			if (_argParser.Build) Build();

--- a/FeedBuilder/frmMain.cs
+++ b/FeedBuilder/frmMain.cs
@@ -65,10 +65,8 @@ namespace FeedBuilder
 				{
 					_argParser.ShowGui = true;
 					_argParser.Build = false;
+					UpdateTitle();
 				}
-
-				FileName = _argParser.FileName;
-				UpdateTitle();
 			}
 			if (_argParser.ShowGui) Show();
 			if (_argParser.Build) Build();

--- a/FeedBuilder/frmMain.cs
+++ b/FeedBuilder/frmMain.cs
@@ -77,16 +77,18 @@ namespace FeedBuilder
 
 		private void InitializeFormSettings()
 		{
-			if (!string.IsNullOrEmpty(Settings.Default.OutputFolder))
+			if (string.IsNullOrEmpty(Settings.Default.OutputFolder))
+			{
+				txtOutputFolder.Text = string.Empty;
+			}
+			else
 			{
 				string path = GetFullDirectoryPath(Settings.Default.OutputFolder);
-
-				if (Directory.Exists(path))
-					txtOutputFolder.Text = Settings.Default.OutputFolder;
+				txtOutputFolder.Text = Directory.Exists(path) ? Settings.Default.OutputFolder : string.Empty;
 			}
 
-			if (!string.IsNullOrEmpty(Settings.Default.FeedXML)) txtFeedXML.Text = Settings.Default.FeedXML;
-			if (!string.IsNullOrEmpty(Settings.Default.BaseURL)) txtBaseURL.Text = Settings.Default.BaseURL;
+			txtFeedXML.Text = string.IsNullOrEmpty(Settings.Default.FeedXML) ? string.Empty : Settings.Default.FeedXML;
+			txtBaseURL.Text = string.IsNullOrEmpty(Settings.Default.BaseURL) ? string.Empty : Settings.Default.BaseURL;
 
 			chkVersion.Checked = Settings.Default.CompareVersion;
 			chkSize.Checked = Settings.Default.CompareSize;

--- a/FeedBuilder/frmMain.cs
+++ b/FeedBuilder/frmMain.cs
@@ -75,7 +75,14 @@ namespace FeedBuilder
 
 		private void InitializeFormSettings()
 		{
-			if (!string.IsNullOrEmpty(Settings.Default.OutputFolder) && Directory.Exists(Settings.Default.OutputFolder)) txtOutputFolder.Text = Settings.Default.OutputFolder;
+			if (!string.IsNullOrEmpty(Settings.Default.OutputFolder))
+			{
+				string path = GetFullDirectoryPath(Settings.Default.OutputFolder);
+
+				if (Directory.Exists(path))
+					txtOutputFolder.Text = Settings.Default.OutputFolder;
+			}
+
 			if (!string.IsNullOrEmpty(Settings.Default.FeedXML)) txtFeedXML.Text = Settings.Default.FeedXML;
 			if (!string.IsNullOrEmpty(Settings.Default.BaseURL)) txtBaseURL.Text = Settings.Default.BaseURL;
 
@@ -421,7 +428,14 @@ namespace FeedBuilder
 
 		private void OpenOutputsFolder()
 		{
-			string dir = Path.GetDirectoryName(txtFeedXML.Text.Trim());
+			string path = txtOutputFolder.Text.Trim();
+
+			if (string.IsNullOrEmpty(path))
+			{
+				return;
+			}
+
+			string dir = GetFullDirectoryPath(path);
 			if (dir == null) return;
 			CreateDirectoryPath(dir);
 			Process process = new Process
@@ -484,10 +498,7 @@ namespace FeedBuilder
 				return;
 			}
 
-			if (!outputDir.EndsWith("\\"))
-			{
-				outputDir += "\\";
-			}
+			outputDir = GetFullDirectoryPath(outputDir);
 
 			lstFiles.BeginUpdate();
 			lstFiles.Items.Clear();
@@ -515,6 +526,23 @@ namespace FeedBuilder
 			}
 
 			lstFiles.EndUpdate();
+		}
+
+		private string GetFullDirectoryPath(string path)
+		{
+			string absolutePath = path;
+
+			if (!Path.IsPathRooted(absolutePath))
+			{
+				absolutePath = Path.Combine(Path.GetDirectoryName(Application.ExecutablePath), path);
+			}
+
+			if (!absolutePath.EndsWith("\\"))
+			{
+				absolutePath += "\\";
+			}
+
+			return Path.GetFullPath(absolutePath);
 		}
 
 		private bool IsIgnorable(string filename)


### PR DESCRIPTION
Changes made to the Feedbuilder tool to allow configs to be saved and used on different machines for the same codebase.

Changes in detail:
- Added support for relative paths in config based on application path.
- Fixed so that current settings are persisted on close as intended.
- Stored configurations should now load properly. Fixes #88.
- Added support to adopt configurations from other machines.
- Fixed an error that could occur if a configuration was saved with one of the textareas left empty.
- Fixed the "New" button functionality.
- Changed so that debug build out is located in the FeedBuilder/bin folder.