### PR TITLE
using AppDomain.CurrentDomain.BaseDirectory instead of Environment.Cu…

### DIFF
--- a/src/NAppUpdate.Framework/Conditions/FileChecksumCondition.cs
+++ b/src/NAppUpdate.Framework/Conditions/FileChecksumCondition.cs
@@ -28,13 +28,15 @@ namespace NAppUpdate.Framework.Conditions
 			if (string.IsNullOrEmpty(localPath))
 				return true;
 
+			var fullPath = FileSystem.GetFullPath(localPath);
+
 			// if the local file does not exist, checksums don't match vacuously
-			if (!File.Exists(localPath))
+			if (!File.Exists(fullPath))
 				return false;
 
 			if ("sha256".Equals(ChecksumType, StringComparison.InvariantCultureIgnoreCase))
 			{
-				var sha256 = FileChecksum.GetSHA256Checksum(localPath);
+				var sha256 = FileChecksum.GetSHA256Checksum(fullPath);
 				if (!string.IsNullOrEmpty(sha256) && sha256.Equals(Checksum, StringComparison.InvariantCultureIgnoreCase))
 					return true;
 			}

--- a/src/NAppUpdate.Framework/Conditions/FileDateCondition.cs
+++ b/src/NAppUpdate.Framework/Conditions/FileDateCondition.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using NAppUpdate.Framework.Common;
+using NAppUpdate.Framework.Utils;
 
 namespace NAppUpdate.Framework.Conditions
 {
@@ -36,13 +37,15 @@ namespace NAppUpdate.Framework.Conditions
 			if (string.IsNullOrEmpty(localPath))
 				return true;
 
+			var fullPath = FileSystem.GetFullPath(localPath);
+
 			// if the file doesn't exist it has a null timestamp, and therefore the condition result depends on the ComparisonType
-			if (!File.Exists(localPath))
+			if (!File.Exists(fullPath))
 				return ComparisonType.Equals("older", StringComparison.InvariantCultureIgnoreCase);
 
 			// File timestamps seem to be off by a little bit (conversion rounding?), so the code below
 			// gets around that
-			var dt = File.GetLastWriteTime(localPath);
+			var dt = File.GetLastWriteTime(fullPath);
 			var localPlus = dt.AddSeconds(2).ToFileTimeUtc();
 			var localMinus = dt.AddSeconds(-2).ToFileTimeUtc();
 			var remoteFileDateTime = Timestamp.ToFileTimeUtc();

--- a/src/NAppUpdate.Framework/Conditions/FileExistsCondition.cs
+++ b/src/NAppUpdate.Framework/Conditions/FileExistsCondition.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using NAppUpdate.Framework.Common;
+using NAppUpdate.Framework.Utils;
 
 namespace NAppUpdate.Framework.Conditions
 {
@@ -21,8 +22,8 @@ namespace NAppUpdate.Framework.Conditions
 			string localPath = !string.IsNullOrEmpty(LocalPath) ? LocalPath : Utils.Reflection.GetNauAttribute(task, "LocalPath") as string;
 			if (string.IsNullOrEmpty(localPath))
 				return true;
-
-			return File.Exists(localPath);
+			var fullPath = FileSystem.GetFullPath(localPath);
+			return File.Exists(fullPath);
 		}
 	}
 }

--- a/src/NAppUpdate.Framework/Conditions/FileSizeCondition.cs
+++ b/src/NAppUpdate.Framework/Conditions/FileSizeCondition.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using NAppUpdate.Framework.Common;
+using NAppUpdate.Framework.Utils;
 
 namespace NAppUpdate.Framework.Conditions
 {
@@ -31,10 +32,12 @@ namespace NAppUpdate.Framework.Conditions
 			if (string.IsNullOrEmpty(localPath))
 				return true;
 
+			var fullPath = FileSystem.GetFullPath(localPath);
+
 			long localFileSize = 0;
-			if (File.Exists(localPath))
+			if (File.Exists(fullPath))
 			{
-				var fi = new FileInfo(localPath);
+				var fi = new FileInfo(fullPath);
 				localFileSize = fi.Length;
 			}
 

--- a/src/NAppUpdate.Framework/Conditions/FileVersionCondition.cs
+++ b/src/NAppUpdate.Framework/Conditions/FileVersionCondition.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Diagnostics;
 using NAppUpdate.Framework.Common;
+using NAppUpdate.Framework.Utils;
 
 namespace NAppUpdate.Framework.Conditions
 {
@@ -30,11 +31,13 @@ namespace NAppUpdate.Framework.Conditions
 			if (string.IsNullOrEmpty(localPath))
 				return true;
 
+			var fullPath = FileSystem.GetFullPath(localPath);
+
 			// if the file doesn't exist it has a null version, and therefore the condition result depends on the ComparisonType
-			if (!File.Exists(localPath))
+			if (!File.Exists(fullPath))
 				return ComparisonType.Equals("below", StringComparison.InvariantCultureIgnoreCase);
 
-			var versionInfo = FileVersionInfo.GetVersionInfo(localPath);
+			var versionInfo = FileVersionInfo.GetVersionInfo(fullPath);
 			if (versionInfo.FileVersion == null) return true; // perform the update if no version info is found
 
 			var localVersion = new Version(versionInfo.FileMajorPart, versionInfo.FileMinorPart, versionInfo.FileBuildPart, versionInfo.FilePrivatePart);

--- a/src/NAppUpdate.Framework/Utils/FileSystem.cs
+++ b/src/NAppUpdate.Framework/Utils/FileSystem.cs
@@ -115,5 +115,11 @@ namespace NAppUpdate.Framework.Utils
 
 			dst.SetAccessControl(fs);
 		}
+
+		public static string GetFullPath(string localPath)
+		{
+			var currentDirectory = AppDomain.CurrentDomain.BaseDirectory;
+			return Path.Combine(currentDirectory, localPath);
+		}
 	}
 }


### PR DESCRIPTION
…rrentDirectory

Issue occurs for example in case when application is called either from windows startup (Environment.CurrentDirectory = user root folder) or from installer.

In these cases File.Exist(localFile) returen false, because no application files in CurrentDirectory exist.